### PR TITLE
Add missing argument to nvim_call_function() call

### DIFF
--- a/lua/popup_preview/nvimlsp.lua
+++ b/lua/popup_preview/nvimlsp.lua
@@ -19,7 +19,7 @@ local get_resolved_item = function(arg)
     if res and not vim.tbl_isempty(res) then
       respond({item = res, selected = arg.selected})
     else
-      api.nvim_call_function("popup_preview#doc#close_floating")
+      api.nvim_call_function("popup_preview#doc#close_floating", {})
     end
   end)
 end


### PR DESCRIPTION
Switched to ddc.vim recently and started using this plugin, but I noticed that with ltex-ls, looking at any option in the menu would sometimes fail with an error because `vim.api.nvim_call_function` wasn't provided the argument table it requires when getting the resolved item; I added an empty one to satisfy it.