### PR TITLE
fix: no returns negative size

### DIFF
--- a/denops/popup_preview/markdown.ts
+++ b/denops/popup_preview/markdown.ts
@@ -93,7 +93,7 @@ export async function makeFloatingwinSize(
     height += Math.floor((w ? w - 1 : 0) / width) + 1;
   }
   height = Math.min(maxHeight, height);
-  return [width, height];
+  return [Math.max(width, 0), Math.max(height, 0)];
 }
 
 /**


### PR DESCRIPTION
Suppresses the error that occurs when the width is too narrow.

Before PR, following error is raised.
```
RangeError: Invalid count value: -1
    at String.repeat (<anonymous>)
    at getHighlights (file:///.../denops/popup_preview/markdown.ts:253:23)
    at async getStylizeCommands (file:///.../denops/popup_preview/markdown.ts:273:22)
    at async DocHandler.showFloating (file:///.../denops/popup_preview/documentation.ts:66:19)
```