### PR TITLE
fix: cannot read properties of undefined (reading abbr)

### DIFF
--- a/denops/popup_preview/documentation.ts
+++ b/denops/popup_preview/documentation.ts
@@ -138,6 +138,9 @@ export class DocHandler {
       return;
     }
     const item = info["items"][res.selected];
+    if (!item) {
+      return;
+    }
     this.docCache[item.abbr || item.word] = {
       lines: maybe.lines,
       index: res.selected,


### PR DESCRIPTION
Fixed a rare `Cannot read properties of undefined (reading 'abbr')` error when starting completion in `ddc.vim + pum.vim + ddc-source-nvim-ls` environment.

![image](https://user-images.githubusercontent.com/44780846/232315887-f88d2ec6-587e-4f4b-92be-a2f8ff3eb3f1.png)
