### PR TITLE
Support ddc-source-vsnip

### DIFF
--- a/denops/popup_preview/deps.ts
+++ b/denops/popup_preview/deps.ts
@@ -1,12 +1,12 @@
-export type { Denops } from "https://deno.land/x/denops_std@v4.0.0/mod.ts";
+export type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 export {
   batch,
-  gather,
-} from "https://deno.land/x/denops_std@v4.0.0/batch/mod.ts";
-export * as op from "https://deno.land/x/denops_std@v4.0.0/option/mod.ts";
-export * as path from "https://deno.land/std@0.173.0/path/mod.ts";
-export * as fn from "https://deno.land/x/denops_std@v4.0.0/function/mod.ts";
-export * as nvimFn from "https://deno.land/x/denops_std@v4.0.0/function/nvim/mod.ts";
-export * as vars from "https://deno.land/x/denops_std@v4.0.0/variable/mod.ts";
-export * as autocmd from "https://deno.land/x/denops_std@v4.0.0/autocmd/mod.ts";
-export { isLike } from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
+  collect,
+} from "https://deno.land/x/denops_std@v5.0.1/batch/mod.ts";
+export * as op from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
+export * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+export * as fn from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
+export * as nvimFn from "https://deno.land/x/denops_std@v5.0.1/function/nvim/mod.ts";
+export * as vars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
+export * as autocmd from "https://deno.land/x/denops_std@v5.0.1/autocmd/mod.ts";
+export { is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";

--- a/denops/popup_preview/integ.ts
+++ b/denops/popup_preview/integ.ts
@@ -1,4 +1,4 @@
-import { Denops, isLike, op } from "./deps.ts";
+import { Denops, is, op } from "./deps.ts";
 import {
   CompletionItem,
   JsonUserData,
@@ -88,7 +88,7 @@ export async function searchUserdata(
   }
   const filetype = await op.filetype.getLocal(denops);
   let decoded: JsonUserData = null;
-  if (isLike({ lspitem: "" }, item.user_data)) {
+  if (is.ObjectOf({ lspitem: is.String })(item.user_data)) {
     decoded = { lspitem: JSON.parse(item.user_data.lspitem) as CompletionItem };
   } else if (typeof item.user_data == "string") {
     try {

--- a/denops/popup_preview/integ.ts
+++ b/denops/popup_preview/integ.ts
@@ -90,6 +90,13 @@ export async function searchUserdata(
   let decoded: JsonUserData = null;
   if (is.ObjectOf({ lspitem: is.String })(item.user_data)) {
     decoded = { lspitem: JSON.parse(item.user_data.lspitem) as CompletionItem };
+  } else if (
+    is.ObjectOf({ vsnip: is.ObjectOf({ snippet: is.ArrayOf(is.String) }) })(
+      item.user_data,
+    )
+  ) {
+    // ddc-source-vsnip
+    decoded = item.user_data;
   } else if (typeof item.user_data == "string") {
     try {
       decoded = JSON.parse(item.user_data) as JsonUserData;

--- a/denops/popup_preview/markdown.ts
+++ b/denops/popup_preview/markdown.ts
@@ -1,4 +1,4 @@
-import { Denops, fn, gather, vars } from "./deps.ts";
+import { collect, Denops, fn, vars } from "./deps.ts";
 type MarkedString = string | { language: string; value: string };
 export type MarkupKind = "plaintext" | "markdown";
 export type MarkupContent = {
@@ -81,11 +81,10 @@ export async function makeFloatingwinSize(
     maxWidth -= 2;
     maxHeight -= 2;
   }
-  const widths = await gather(denops, async (denops) => {
-    for (const line of lines) {
-      await fn.strdisplaywidth(denops, line);
-    }
-  }) as number[];
+  const widths = await collect(
+    denops,
+    (denops) => lines.map((line) => fn.strdisplaywidth(denops, line)),
+  );
   const width = Math.min(Math.max(...widths), maxWidth);
 
   let height = 0;


### PR DESCRIPTION
ddc.vim has stopped relying on vsnip-integ and now uses the source [here](https://github.com/uga-rosa/ddc-source-vsnip).
This will be a PR to add that support.
