### PR TITLE
The link to hl-PopupPreviewBorder is different from the documentation

### DIFF
--- a/autoload/popup_preview.vim
+++ b/autoload/popup_preview.vim
@@ -38,7 +38,7 @@ endfunction
 
 function! s:init_highlight() abort
   highlight default link PopupPreviewDocument NormalFloat
-  highlight default link PopupPreviewBorder NormalFloat
+  highlight default link PopupPreviewBorder FloatBorder
 endfunction
 
 function! popup_preview#notify(method, arg) abort


### PR DESCRIPTION
The link to hl-PopupPreviewBorder in the documentation is “FloatBorder”, but it is now “NormalFloat”.
This pull request will correct the actual link destination to “FloatBorder”.
If this change is not a problem for Matsui-san, I will send a similar PR to denops-signature_help later.
Thanks,