### PR TITLE
Update deps and fix errors

### DIFF
--- a/denops/popup_preview/deps.ts
+++ b/denops/popup_preview/deps.ts
@@ -1,12 +1,12 @@
-export type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+export type { Denops } from "https://deno.land/x/denops_std@v6.5.1/mod.ts";
 export {
   batch,
   collect,
-} from "https://deno.land/x/denops_std@v5.0.1/batch/mod.ts";
-export * as op from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
-export * as path from "https://deno.land/std@0.192.0/path/mod.ts";
-export * as fn from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
-export * as nvimFn from "https://deno.land/x/denops_std@v5.0.1/function/nvim/mod.ts";
-export * as vars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
-export * as autocmd from "https://deno.land/x/denops_std@v5.0.1/autocmd/mod.ts";
-export { is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
+} from "https://deno.land/x/denops_std@v6.5.1/batch/mod.ts";
+export * as op from "https://deno.land/x/denops_std@v6.5.1/option/mod.ts";
+export * as path from "https://deno.land/std@0.224.0/path/mod.ts";
+export * as fn from "https://deno.land/x/denops_std@v6.5.1/function/mod.ts";
+export * as nvimFn from "https://deno.land/x/denops_std@v6.5.1/function/nvim/mod.ts";
+export * as vars from "https://deno.land/x/denops_std@v6.5.1/variable/mod.ts";
+export * as autocmd from "https://deno.land/x/denops_std@v6.5.1/autocmd/mod.ts";
+export { is } from "https://deno.land/x/unknownutil@v3.18.1/mod.ts";

--- a/denops/popup_preview/deps_test.ts
+++ b/denops/popup_preview/deps_test.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.173.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.224.0/testing/asserts.ts";

--- a/denops/popup_preview/markdown_test.ts
+++ b/denops/popup_preview/markdown_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "./deps_test.ts";
-import { test } from "https://deno.land/x/denops_test@v1.1.0/mod.ts";
+import { test } from "https://deno.land/x/denops_test@v1.8.0/mod.ts";
 import { path, vars } from "./deps.ts";
 import {
   convertInputToMarkdownLines,

--- a/lua/popup_preview/nvimlsp.lua
+++ b/lua/popup_preview/nvimlsp.lua
@@ -14,7 +14,7 @@ end
 local get_resolved_item = function(arg)
   local item = arg.decoded
   -- ignore E5018: Some language server make boolean a key of CompletionItem
-  pcall(vim.lsp.buf_request, 0, 'completionItem/resolve', item, function(_, arg1, arg2)
+  pcall(vim.lsp.buf_request_all, 0, 'completionItem/resolve', item, function(_, arg1, arg2)
     local res = is_new_handler(arg1) and arg1 or arg2
     if res and not vim.tbl_isempty(res) then
       respond({item = res, selected = arg.selected})


### PR DESCRIPTION
I have updated deps version and I have fixed the error.

`vim.lsp.buf_request` is invalid.