### PR TITLE
Support ddc previewer

### DIFF
--- a/denops/popup_preview/deps.ts
+++ b/denops/popup_preview/deps.ts
@@ -9,4 +9,12 @@ export * as fn from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
 export * as nvimFn from "https://deno.land/x/denops_std@v5.0.1/function/nvim/mod.ts";
 export * as vars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
 export * as autocmd from "https://deno.land/x/denops_std@v5.0.1/autocmd/mod.ts";
-export { is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
+export {
+  is,
+  type Predicate,
+} from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
+export type {
+  DdcItem,
+  PreviewContext,
+  Previewer,
+} from "jsr:@shougo/ddc-vim@9/types";

--- a/denops/popup_preview/integ.ts
+++ b/denops/popup_preview/integ.ts
@@ -144,7 +144,7 @@ export async function searchUserdata(
   if ("lspitem" in decoded) {
     if (decoded.lspitem.documentation) {
       return getLspContents(decoded.lspitem, filetype);
-    } else {
+    } else if (denops.meta.host === "nvim") {
       denops.call(
         "luaeval",
         "require('popup_preview.nvimlsp').get_resolved_item(_A.arg)",

--- a/denops/popup_preview/integ.ts
+++ b/denops/popup_preview/integ.ts
@@ -1,4 +1,12 @@
-import { Denops, is, op } from "./deps.ts";
+import {
+  DdcItem,
+  Denops,
+  is,
+  op,
+  Predicate,
+  PreviewContext,
+  Previewer,
+} from "./deps.ts";
 import {
   CompletionItem,
   JsonUserData,
@@ -77,12 +85,67 @@ export function getLspContents(
   return { lines: lines, found: true };
 }
 
+async function getDdcPreviewerContents(
+  denops: Denops,
+  item: DdcItem,
+  config: Config,
+): Promise<string[] | null> {
+  const context: PreviewContext = {
+    height: config.maxHeight,
+    width: config.maxWidth,
+    isFloating: true,
+  };
+  const previewer = await denops.dispatch(
+    "ddc",
+    "getPreviewer",
+    item,
+    context,
+  ) as Previewer;
+  const { kind } = previewer;
+  switch (kind) {
+    case "empty":
+      break; // no data
+    case "command":
+      break; // not implemented
+    case "help":
+      break; // not implemented
+    case "markdown": {
+      if (previewer.contents.length === 0) break; // no data
+      return previewer.contents;
+    }
+    case "text": {
+      if (previewer.contents.length === 0) break; // no data
+      return convertInputToMarkdownLines({
+        kind: "plaintext",
+        value: previewer.contents.join("\n"),
+      }, []);
+    }
+    default: {
+      kind satisfies never; // exhaustive check
+      break; // unknown kind
+    }
+  }
+  return null;
+}
+
+const isDdcItemLike = is.ObjectOf({
+  __sourceName: is.String,
+}) satisfies Predicate<Pick<DdcItem, "__sourceName">>;
+
 export async function searchUserdata(
   denops: Denops,
-  item: VimCompleteItem,
+  item: VimCompleteItem | DdcItem,
   config: Config,
   selected: number,
 ): Promise<SearchResult> {
+  // ddc-previewer
+  if (isDdcItemLike(item)) {
+    const lines = await getDdcPreviewerContents(denops, item, config);
+    if (lines) {
+      return { lines, found: true };
+    }
+  }
+
   if (!item.user_data) {
     return getInfoField(item, config);
   }


### PR DESCRIPTION
Add support for ddc-previewer.

Retrieves preview information from ddc-previewer for ddc.vim output items. If no preview contents is available, falls back to the existing logic.
